### PR TITLE
Fix parsing error for lifecycleMappingMetadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
 									<pluginExecutionFilter>
 										<groupId>org.apache.maven.plugins</groupId>
 										<artifactId>maven-dependency-plugin</artifactId>
-										<version>2.4</version>
+										<versionRange>2.4</versionRange>
 										<goals>
 											<goal>copy</goal>
 										</goals>


### PR DESCRIPTION
Expected tag name is versionRange, not version.
